### PR TITLE
composer: min PHP 5.4 added

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,7 @@
         ]
     },
     "require": {
+        "php": ">=5.4",
         "nikic/php-parser": "1.2.*@dev"
     }
 }


### PR DESCRIPTION
Based on `[]` used in code. Or is it higher?